### PR TITLE
Update fibonacci.cpp

### DIFF
--- a/algorithms_and_data_structures/dynamic_programming_problems/fibonacci.cpp
+++ b/algorithms_and_data_structures/dynamic_programming_problems/fibonacci.cpp
@@ -6,14 +6,17 @@
 #include <vector>
 
 //bottom up
+std::vector<int> fib(2000, 0);
+fib[0]=1;
+fib[1]=1;
 
 int fib1(int n) {
-	std::vector<int> fib(n, 0);
+//	std::vector<int> fib(n, 0);
 	if ( n == 0 || n == 1 ) {
 		return 1;
 	}
-	fib[0] = 1;
-	fib[1] = 1;
+//	fib[0] = 1;
+//	fib[1] = 1;
 	for ( int i = 2; i < n; ++i ) {
 		fib[i] = fib[i-1] + fib[i-2];
 	}
@@ -22,7 +25,7 @@ int fib1(int n) {
 
 //top down
 
-std::vector<int> fib(1000, 0);
+//std::vector<int> fib(1000, 0);
 int fib2( int n ) {
 	if ( n == 0 ) {
 		return 0;


### PR DESCRIPTION
수열을 저장하는 벡터를  함수 밖 전역변수로 옮겼음

초기 낮은 수들에 대해 계산 할 때는 bottom up방식이 빠르고
어느 정도 저장이 되면 top down방식이 빠름
-> 전역 변수로 수열을 저장하여 초반에 fib1함수로 계산한 수열들을 후에
fib2를 사용 할 때도 사용 가능하도록 하였음
-> 많은 양을 계산 할 때 속도 더 빠르게 할 수 있음